### PR TITLE
chore: use `unreachable!` in `Exn::error`

### DIFF
--- a/exn/src/impls.rs
+++ b/exn/src/impls.rs
@@ -112,7 +112,7 @@ impl<E: Error + Send + Sync + 'static> Exn<E> {
         self.frame
             .error()
             .downcast_ref()
-            .expect("error type must match")
+            .unwrap_or_else(|| unreachable!("error type must match"))
     }
 
     /// Return the underlying exception frame.


### PR DESCRIPTION
Since the type _must_ match by construction, `unreachable!` more directly documents the expected behavior than `Option::expect`.