### PR TITLE
feat: use more compact default Debug format

### DIFF
--- a/examples/src/antipattern.rs
+++ b/examples/src/antipattern.rs
@@ -89,7 +89,5 @@ mod http {
 // Notice "failed to send request" appears twice with no new information.
 //
 // Error: fatal error occurred in application, at examples/src/antipattern.rs:35:16
-// |
-// |-> failed to send request, at examples/src/antipattern.rs:59:34
-// |
-// |-> failed to send request to server: 127.0.0.1, at examples/src/antipattern.rs:75:9
+// |-- failed to send request, at examples/src/antipattern.rs:59:34
+// `-- failed to send request to server: 127.0.0.1, at examples/src/antipattern.rs:75:9

--- a/examples/src/basic.rs
+++ b/examples/src/basic.rs
@@ -72,7 +72,5 @@ mod http {
 // Output when running `cargo run --example basic`:
 //
 // Error: fatal error occurred in application, at examples/src/basic.rs:34:16
-// |
-// |-> failed to run app, at examples/src/basic.rs:49:14
-// |
-// |-> failed to send request to server: https://example.com, at examples/src/basic.rs:62:9
+// |-- failed to run app, at examples/src/basic.rs:49:14
+// `-- failed to send request to server: https://example.com, at examples/src/basic.rs:62:9

--- a/examples/src/downcast.rs
+++ b/examples/src/downcast.rs
@@ -120,7 +120,5 @@ mod http {
 //
 // HTTP error with status code: 503
 // Error: fatal error occurred in application, at examples/src/downcast.rs:54:24
-// |
-// |-> failed to run app, at examples/src/downcast.rs:82:35
-// |
-// |-> HTTP 503: service unavailable, at examples/src/downcast.rs:95:9
+// |-- failed to run app, at examples/src/downcast.rs:82:35
+// `-- HTTP 503: service unavailable, at examples/src/downcast.rs:95:9

--- a/examples/src/from-anyhow.rs
+++ b/examples/src/from-anyhow.rs
@@ -66,9 +66,6 @@ mod legacy {
 // Output when running `cargo run -p examples --example from-anyhow`:
 //
 // Error: fatal error occurred in application, at examples/src/from-anyhow.rs:27:16
-// |
-// |-> failed to run app, at examples/src/from-anyhow.rs:42:14
-// |
-// |-> PORT must be a number; got "not-a-number", at exn-anyhow/src/lib.rs:51:19
-// |
-// |-> invalid digit found in string, at exn-anyhow/src/lib.rs:48:19
+// |-- failed to run app, at examples/src/from-anyhow.rs:42:14
+// |-- PORT must be a number; got "not-a-number", at exn-anyhow/src/lib.rs:51:19
+// `-- invalid digit found in string, at exn-anyhow/src/lib.rs:48:19

--- a/examples/src/into-std-error.rs
+++ b/examples/src/into-std-error.rs
@@ -65,7 +65,5 @@ mod config {
 // Output when running `cargo run -p examples --example into-std-error`:
 //
 // Error: failed to start app, at examples/src/into-std-error.rs:36:40
-// |
-// |-> PORT must be a number; got "not-a-number", at examples/src/into-std-error.rs:55:14
-// |
-// |-> invalid digit found in string, at examples/src/into-std-error.rs:55:14
+// |-- PORT must be a number; got "not-a-number", at examples/src/into-std-error.rs:55:14
+// `-- invalid digit found in string, at examples/src/into-std-error.rs:55:14

--- a/examples/src/library-boundary.rs
+++ b/examples/src/library-boundary.rs
@@ -252,15 +252,11 @@ mod library {
 //
 // Action: Retried too many times, aborting
 // Error: RateLimited: rate limited by upstream, at examples/src/library-boundary.rs:149:13
-// |
-// |-> failed to fetch profile for user 429, at examples/src/library-boundary.rs:170:55
-// |
-// |-> HTTP 429: too many requests, at examples/src/library-boundary.rs:218:24
+// |-- failed to fetch profile for user 429, at examples/src/library-boundary.rs:170:55
+// `-- HTTP 429: too many requests, at examples/src/library-boundary.rs:218:24
 //
 // Start demo for user: 404
 // Action: Return 404
 // Error: NotFound: user 404 not found, at examples/src/library-boundary.rs:149:13
-// |
-// |-> failed to fetch profile for user 404, at examples/src/library-boundary.rs:169:47
-// |
-// |-> no row for user_id 404, at examples/src/library-boundary.rs:189:24
+// |-- failed to fetch profile for user 404, at examples/src/library-boundary.rs:169:47
+// `-- no row for user_id 404, at examples/src/library-boundary.rs:189:24

--- a/exn/src/debug.rs
+++ b/exn/src/debug.rs
@@ -47,11 +47,16 @@ fn write_exn(f: &mut fmt::Formatter<'_>, frame: &Frame, level: usize, prefix: &s
     let children_len = children.len();
 
     for (i, child) in children.iter().enumerate() {
-        write!(f, "\n{}|", prefix)?;
-        write!(f, "\n{}|-> ", prefix)?;
-
         let child_child_len = child.children().len();
-        if level == 0 && children_len == 1 && child_child_len == 1 {
+        let is_linear = level == 0 && children_len == 1 && child_child_len == 1;
+
+        if i != children_len - 1 || is_linear {
+            write!(f, "\n{}|-- ", prefix)?;
+        } else {
+            write!(f, "\n{}`-- ", prefix)?;
+        }
+
+        if is_linear {
             write_exn(f, child, 0, prefix)?;
         } else if i < children_len - 1 {
             write_exn(f, child, level + 1, &format!("{}|   ", prefix))?;

--- a/exn/src/lib.rs
+++ b/exn/src/lib.rs
@@ -68,8 +68,7 @@
 //!
 //! ```text
 //! fatal error: math no longer works, at exn/src/lib.rs:44:16
-//! |
-//! |-> logic error: 0 == 1, at exn/src/lib.rs:40:5
+//! `-- logic error: 0 == 1, at exn/src/lib.rs:40:5
 //! ```
 
 #![cfg_attr(docsrs, feature(doc_cfg))]

--- a/exn/tests/main.rs
+++ b/exn/tests/main.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use exn::ErrorExt;
 use exn::Exn;
 use exn::OptionExt;
 use exn::ResultExt;
@@ -23,6 +24,15 @@ use common::ErrorWithSource;
 #[test]
 fn linear_error() {
     let e = common::new_linear_error().raise(Error("topmost"));
+    assert_eq!(e.to_string(), "topmost");
+    insta::assert_debug_snapshot!(e);
+}
+
+#[test]
+fn tree_then_linear_error() {
+    let t1 = common::new_linear_error().raise(Error("T1"));
+    let t2 = Error("T2").raise();
+    let e = Exn::raise_all(Error("topmost"), [t1, t2]);
     assert_eq!(e.to_string(), "topmost");
     insta::assert_debug_snapshot!(e);
 }

--- a/exn/tests/snapshots/main__bail.snap
+++ b/exn/tests/snapshots/main__bail.snap
@@ -2,4 +2,4 @@
 source: exn/tests/main.rs
 expression: result.unwrap_err()
 ---
-An error, at exn/tests/main.rs:71:9
+An error, at exn/tests/main.rs:81:9

--- a/exn/tests/snapshots/main__ensure_fail.snap
+++ b/exn/tests/snapshots/main__ensure_fail.snap
@@ -2,4 +2,4 @@
 source: exn/tests/main.rs
 expression: result.unwrap_err()
 ---
-An error, at exn/tests/main.rs:91:9
+An error, at exn/tests/main.rs:101:9

--- a/exn/tests/snapshots/main__from_error.snap
+++ b/exn/tests/snapshots/main__from_error.snap
@@ -2,4 +2,4 @@
 source: exn/tests/main.rs
 expression: result.unwrap_err()
 ---
-An error, at exn/tests/main.rs:60:9
+An error, at exn/tests/main.rs:70:9

--- a/exn/tests/snapshots/main__linear_error.snap
+++ b/exn/tests/snapshots/main__linear_error.snap
@@ -2,14 +2,9 @@
 source: exn/tests/main.rs
 expression: e
 ---
-topmost, at exn/tests/main.rs:25:40
-|
-|-> E5, at exn/tests/common.rs:44:8
-|
-|-> E4, at exn/tests/common.rs:43:17
-|
-|-> E3, at exn/tests/common.rs:42:17
-|
-|-> E2, at exn/tests/common.rs:41:17
-|
-|-> E1, at exn/tests/common.rs:40:26
+topmost, at exn/tests/main.rs:26:40
+|-- E5, at exn/tests/common.rs:44:8
+|-- E4, at exn/tests/common.rs:43:17
+|-- E3, at exn/tests/common.rs:42:17
+|-- E2, at exn/tests/common.rs:41:17
+`-- E1, at exn/tests/common.rs:40:26

--- a/exn/tests/snapshots/main__new_with_source.snap
+++ b/exn/tests/snapshots/main__new_with_source.snap
@@ -2,6 +2,5 @@
 source: exn/tests/main.rs
 expression: e
 ---
-top, at exn/tests/main.rs:39:13
-|
-|-> source, at exn/tests/main.rs:39:13
+top, at exn/tests/main.rs:49:13
+`-- source, at exn/tests/main.rs:49:13

--- a/exn/tests/snapshots/main__option_ext.snap
+++ b/exn/tests/snapshots/main__option_ext.snap
@@ -2,4 +2,4 @@
 source: exn/tests/main.rs
 expression: result.unwrap_err()
 ---
-An error, at exn/tests/main.rs:53:25
+An error, at exn/tests/main.rs:63:25

--- a/exn/tests/snapshots/main__result_ext.snap
+++ b/exn/tests/snapshots/main__result_ext.snap
@@ -2,6 +2,5 @@
 source: exn/tests/main.rs
 expression: result.unwrap_err()
 ---
-Another error, at exn/tests/main.rs:46:25
-|
-|-> An error, at exn/tests/main.rs:46:25
+Another error, at exn/tests/main.rs:56:25
+`-- An error, at exn/tests/main.rs:56:25

--- a/exn/tests/snapshots/main__tree_error.snap
+++ b/exn/tests/snapshots/main__tree_error.snap
@@ -2,28 +2,16 @@
 source: exn/tests/main.rs
 expression: e
 ---
-topmost, at exn/tests/main.rs:32:38
-|
-|-> E6, at exn/tests/common.rs:36:5
-    |
-    |-> E5, at exn/tests/common.rs:28:14
-    |   |
-    |   |-> E3, at exn/tests/common.rs:20:17
-    |   |   |
-    |   |   |-> E1, at exn/tests/common.rs:19:26
-    |   |
-    |   |-> E10, at exn/tests/common.rs:23:18
-    |   |   |
-    |   |   |-> E9, at exn/tests/common.rs:22:26
-    |   |
-    |   |-> E12, at exn/tests/common.rs:26:19
-    |       |
-    |       |-> E11, at exn/tests/common.rs:25:28
-    |
-    |-> E4, at exn/tests/common.rs:31:17
-    |   |
-    |   |-> E2, at exn/tests/common.rs:30:26
-    |
-    |-> E8, at exn/tests/common.rs:34:17
-        |
-        |-> E7, at exn/tests/common.rs:33:26
+topmost, at exn/tests/main.rs:42:38
+`-- E6, at exn/tests/common.rs:36:5
+    |-- E5, at exn/tests/common.rs:28:14
+    |   |-- E3, at exn/tests/common.rs:20:17
+    |   |   `-- E1, at exn/tests/common.rs:19:26
+    |   |-- E10, at exn/tests/common.rs:23:18
+    |   |   `-- E9, at exn/tests/common.rs:22:26
+    |   `-- E12, at exn/tests/common.rs:26:19
+    |       `-- E11, at exn/tests/common.rs:25:28
+    |-- E4, at exn/tests/common.rs:31:17
+    |   `-- E2, at exn/tests/common.rs:30:26
+    `-- E8, at exn/tests/common.rs:34:17
+        `-- E7, at exn/tests/common.rs:33:26

--- a/exn/tests/snapshots/main__tree_then_linear_error.snap
+++ b/exn/tests/snapshots/main__tree_then_linear_error.snap
@@ -1,0 +1,12 @@
+---
+source: exn/tests/main.rs
+expression: e
+---
+topmost, at exn/tests/main.rs:35:13
+|-- T1, at exn/tests/main.rs:33:41
+|   `-- E5, at exn/tests/common.rs:44:8
+|       `-- E4, at exn/tests/common.rs:43:17
+|           `-- E3, at exn/tests/common.rs:42:17
+|               `-- E2, at exn/tests/common.rs:41:17
+|                   `-- E1, at exn/tests/common.rs:40:26
+`-- T2, at exn/tests/main.rs:34:26


### PR DESCRIPTION
Removes the empty line between errors and use box-drawing characters for compact rendering.