### PR TITLE
chore: release v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All significant changes to this project will be documented in this file.
 
 ## Unreleased
 
+## v0.3.1 (2026-05-06)
+
+### New Features
+
+* Use a more compact ASCII tree format for default `Debug` output.
+
+### Bug Fixes
+
+* Fix conversion from `Exn<E>` into boxed `std::error::Error` trait objects.
+
 ## v0.3.0 (2026-01-31)
 
 ### Breaking Changes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -194,7 +194,7 @@ dependencies = [
 
 [[package]]
 name = "exn"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "insta",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ rust-version = "1.85.0"
 
 [workspace.dependencies]
 # Workspace dependencies
-exn = { version = "0.3.0", path = "exn" }
+exn = { version = "0.3.1", path = "exn" }
 exn-anyhow = { version = "0.1.0", path = "exn-anyhow" }
 
 # Crates.io dependencies

--- a/exn/Cargo.toml
+++ b/exn/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "exn"
-version = "0.3.0"
+version = "0.3.1"
 
 description = "A context-aware concrete Error type built on `core::error::Error`."
 


### PR DESCRIPTION
## Summary

- Release `exn` v0.3.1.
- Document the compact ASCII `Debug` output change.
- Document the boxed `std::error::Error` conversion fix.
- Bump `exn` version references in the manifests and lockfile.