### PR TITLE
chore: harden independent release workflow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,9 +63,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "bitflags"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ exn = { version = "0.3.1", path = "exn" }
 exn-anyhow = { version = "0.1.0", path = "exn-anyhow" }
 
 # Crates.io dependencies
-anyhow = { version = "1.0.100" }
+anyhow = { version = "1.0.104" }
 clap = { version = "4.5.20", features = ["derive"] }
 insta = { version = "1.45.1" }
 parse-display = { version = "0.11.0", features = ["default"] }
@@ -44,7 +44,6 @@ unused_must_use = "deny"
 dbg_macro = "deny"
 
 [workspace.metadata.release]
-pre-release-commit-message = "chore: release v{{version}}"
-shared-version = true
+consolidate-commits = false
+dependent-version = "upgrade"
 sign-tag = true
-tag-name = "v{{version}}"

--- a/exn-anyhow/Cargo.toml
+++ b/exn-anyhow/Cargo.toml
@@ -29,5 +29,9 @@ rust-version.workspace = true
 anyhow = { workspace = true }
 exn = { workspace = true }
 
+[package.metadata.release]
+pre-release-commit-message = "chore: release {{crate_name}} v{{version}}"
+tag-name = "{{crate_name}}-v{{version}}"
+
 [lints]
 workspace = true

--- a/exn/Cargo.toml
+++ b/exn/Cargo.toml
@@ -29,6 +29,10 @@ rust-version.workspace = true
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
+[package.metadata.release]
+pre-release-commit-message = "chore: release v{{version}}"
+tag-name = "v{{version}}"
+
 [dev-dependencies]
 insta = { workspace = true }
 

--- a/exn/src/impls.rs
+++ b/exn/src/impls.rs
@@ -45,13 +45,13 @@ impl<E: Error + Send + Sync + 'static> Exn<E> {
     /// This will automatically walk the [source chain of the error] and add them as children
     /// frames.
     ///
-    /// See also [`ErrorExt::raise`] for a fluent way to convert an error into an `Exn` instance.
+    /// See also [`ErrorExt::raise`](crate::ErrorExt::raise) for a fluent way to convert an error
+    /// into an `Exn` instance.
     ///
     /// Note that **sources of `error` are degenerated to their string representation** and all type
     /// information is erased.
     ///
     /// [source chain of the error]: Error::source
-    /// [`ErrorExt::raise`](crate::ErrorExt)
     #[track_caller]
     pub fn new(error: E) -> Self {
         struct SourceError(String);

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -81,6 +81,7 @@ impl CommandLint {
         run_command(make_taplo_cmd(self.fix));
         run_command(make_typos_cmd());
         run_command(make_hawkeye_cmd(self.fix));
+        run_command(make_doc_cmd());
     }
 }
 
@@ -167,6 +168,19 @@ fn make_clippy_cmd(fix: bool) -> StdCommand {
     } else {
         cmd.args(["--", "-D", "warnings"]);
     }
+    cmd
+}
+
+fn make_doc_cmd() -> StdCommand {
+    let mut cmd = find_command("cargo");
+    cmd.env("RUSTDOCFLAGS", "-D warnings --cfg docsrs");
+    cmd.args([
+        "+nightly",
+        "doc",
+        "--workspace",
+        "--all-features",
+        "--no-deps",
+    ]);
     cmd
 }
 


### PR DESCRIPTION
## Summary

- Update `anyhow` to 1.0.104, resolving RUSTSEC-2026-0190.
- Release `exn` and `exn-anyhow` independently with package-specific commit and tag conventions.
- Add the strict docs.rs-style build from `fast/template` to `cargo x lint` and fix the broken `ErrorExt::raise` rustdoc link.

## Release behavior

- `cargo release minor -p exn` plans `exn 0.4.0` with tag `v0.4.0`.
- `cargo release minor -p exn-anyhow` plans `exn-anyhow 0.2.0` with tag `exn-anyhow-v0.2.0`.
- `consolidate-commits = false` ensures each package's release commit template is honored.
- `dependent-version = "upgrade"` updates the workspace dependency after releasing `exn`; `exn-anyhow` can then be released separately.

The intended order is `exn` first, followed by `exn-anyhow`.

## Validation

- `cargo x lint`
- `cargo x test --no-capture`
- `cargo x build --locked`
- `cargo deny check advisories`
- Independent `cargo release minor -p <crate> --no-confirm` dry runs
- Full no-publish/no-push release sequence in a temporary clone
