### PR TITLE
feat: add explicit Exn type erasure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ All significant changes to this project will be documented in this file.
 * Replace `Exn::raise_all(parent, children)` with `children.into_iter().raise(parent)` from the new `IteratorExt` trait.
 * Remove the unused `ResultExt::Error` associated type.
 
+### New Features
+
+* Add the allocation-free `Exn::erase` conversion for callback boundaries that cannot name one concrete root error type.
+
 ## v0.3.1 (2026-05-06)
 
 ### New Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ All significant changes to this project will be documented in this file.
 
 ### New Features
 
-* Add the allocation-free `Exn::erase` conversion for callback boundaries that cannot name one concrete root error type.
+* Add `ErasedExn` and the allocation-free `Exn::erase` conversion for callback boundaries that cannot name one concrete root error type.
 
 ## v0.3.1 (2026-05-06)
 

--- a/exn/src/impls.rs
+++ b/exn/src/impls.rs
@@ -103,6 +103,49 @@ impl<E: Error + Send + Sync + 'static> Exn<E> {
 }
 
 impl<E: Error + Send + Sync + 'static + ?Sized> Exn<E> {
+    /// Erase the compile-time root error type of this exception.
+    ///
+    /// This conversion does not allocate or change the exception tree. The concrete root error
+    /// remains available at runtime through `Error::downcast_ref`.
+    ///
+    /// Type erasure is useful at callback boundaries that need one return type for callbacks with
+    /// different concrete error types. Prefer a typed [`Exn<E>`](Exn) away from such boundaries.
+    ///
+    /// ```
+    /// use core::error::Error;
+    /// use core::fmt;
+    ///
+    /// use exn::ErrorExt;
+    /// use exn::Exn;
+    /// use exn::ResultExt;
+    ///
+    /// type CallbackExn = Exn<dyn Error + Send + Sync + 'static>;
+    ///
+    /// fn callback() -> Result<(), CallbackExn> {
+    ///     let result: exn::Result<(), std::io::Error> =
+    ///         Err(std::io::Error::other("callback failed").raise());
+    ///     result.map_err(Exn::erase)
+    /// }
+    ///
+    /// fn run(callback: impl FnOnce() -> Result<(), CallbackExn>) -> exn::Result<(), fmt::Error> {
+    ///     callback().or_raise(|| fmt::Error)
+    /// }
+    ///
+    /// let error = run(callback).unwrap_err();
+    /// assert!(
+    ///     error.frame().children()[0]
+    ///         .error()
+    ///         .downcast_ref::<std::io::Error>()
+    ///         .is_some()
+    /// );
+    /// ```
+    pub fn erase(self) -> Exn<dyn Error + Send + Sync + 'static> {
+        Exn {
+            frame: self.frame,
+            phantom: PhantomData,
+        }
+    }
+
     /// Raise a new exception; this will make the current exception a child of the new one.
     #[track_caller]
     pub fn raise<T: Error + Send + Sync + 'static>(self, err: T) -> Exn<T> {
@@ -145,6 +188,14 @@ where
             .error()
             .downcast_ref()
             .expect("error type must match")
+    }
+}
+
+impl Deref for Exn<dyn Error + Send + Sync + 'static> {
+    type Target = dyn Error + Send + Sync + 'static;
+
+    fn deref(&self) -> &Self::Target {
+        self.frame.error()
     }
 }
 

--- a/exn/src/impls.rs
+++ b/exn/src/impls.rs
@@ -25,6 +25,13 @@ use core::panic::Location;
 
 use crate::iterator::IteratorExt;
 
+/// An [`Exn`] whose compile-time root error type has been erased.
+///
+/// Use this at boundaries such as callbacks that need one error type for implementations with
+/// different concrete root errors. Prefer a typed [`Exn<E>`](Exn) away from those boundaries.
+/// Create an `ErasedExn` with [`Exn::erase`].
+pub type ErasedExn = Exn<dyn Error + Send + Sync + 'static>;
+
 /// An exception type that can hold an error tree and additional context.
 ///
 /// `E` identifies the root error type but is not stored inline, so it may be unsized. Operations
@@ -112,22 +119,20 @@ impl<E: Error + Send + Sync + 'static + ?Sized> Exn<E> {
     /// different concrete error types. Prefer a typed [`Exn<E>`](Exn) away from such boundaries.
     ///
     /// ```
-    /// use core::error::Error;
     /// use core::fmt;
     ///
+    /// use exn::ErasedExn;
     /// use exn::ErrorExt;
     /// use exn::Exn;
     /// use exn::ResultExt;
     ///
-    /// type CallbackExn = Exn<dyn Error + Send + Sync + 'static>;
-    ///
-    /// fn callback() -> Result<(), CallbackExn> {
+    /// fn callback() -> Result<(), ErasedExn> {
     ///     let result: exn::Result<(), std::io::Error> =
     ///         Err(std::io::Error::other("callback failed").raise());
     ///     result.map_err(Exn::erase)
     /// }
     ///
-    /// fn run(callback: impl FnOnce() -> Result<(), CallbackExn>) -> exn::Result<(), fmt::Error> {
+    /// fn run(callback: impl FnOnce() -> Result<(), ErasedExn>) -> exn::Result<(), fmt::Error> {
     ///     callback().or_raise(|| fmt::Error)
     /// }
     ///
@@ -139,7 +144,7 @@ impl<E: Error + Send + Sync + 'static + ?Sized> Exn<E> {
     ///         .is_some()
     /// );
     /// ```
-    pub fn erase(self) -> Exn<dyn Error + Send + Sync + 'static> {
+    pub fn erase(self) -> ErasedExn {
         Exn {
             frame: self.frame,
             phantom: PhantomData,
@@ -191,7 +196,7 @@ where
     }
 }
 
-impl Deref for Exn<dyn Error + Send + Sync + 'static> {
+impl Deref for ErasedExn {
     type Target = dyn Error + Send + Sync + 'static;
 
     fn deref(&self) -> &Self::Target {

--- a/exn/src/lib.rs
+++ b/exn/src/lib.rs
@@ -88,6 +88,7 @@ mod result;
 
 pub use self::ext::ErrorExt;
 pub use self::ext::Ok;
+pub use self::impls::ErasedExn;
 pub use self::impls::Exn;
 pub use self::impls::Frame;
 pub use self::iterator::IteratorExt;

--- a/exn/tests/erasure.rs
+++ b/exn/tests/erasure.rs
@@ -15,12 +15,11 @@
 use core::error::Error;
 use core::fmt;
 
+use exn::ErasedExn;
 use exn::ErrorExt;
 use exn::Exn;
 use exn::IteratorExt;
 use exn::ResultExt;
-
-type CallbackExn = Exn<dyn Error + Send + Sync + 'static>;
 
 #[derive(Debug)]
 struct StorageError;
@@ -74,18 +73,18 @@ fn parse_input() -> exn::Result<(), ParseError> {
     Err(ParseError.raise())
 }
 
-fn storage_callback() -> Result<(), CallbackExn> {
+fn storage_callback() -> Result<(), ErasedExn> {
     read_storage().map_err(Exn::erase)?;
     Ok(())
 }
 
-fn parse_callback() -> Result<(), CallbackExn> {
+fn parse_callback() -> Result<(), ErasedExn> {
     parse_input().map_err(Exn::erase)?;
     Ok(())
 }
 
 fn run_callback(
-    callback: impl FnOnce() -> Result<(), CallbackExn>,
+    callback: impl FnOnce() -> Result<(), ErasedExn>,
 ) -> exn::Result<(), CallbackFailed> {
     callback().or_raise(|| CallbackFailed)
 }

--- a/exn/tests/erasure.rs
+++ b/exn/tests/erasure.rs
@@ -1,0 +1,136 @@
+// Copyright 2025 FastLabs Developers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use core::error::Error;
+use core::fmt;
+
+use exn::ErrorExt;
+use exn::Exn;
+use exn::IteratorExt;
+use exn::ResultExt;
+
+type CallbackExn = Exn<dyn Error + Send + Sync + 'static>;
+
+#[derive(Debug)]
+struct StorageError;
+
+impl fmt::Display for StorageError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("storage failed")
+    }
+}
+
+impl Error for StorageError {}
+
+#[derive(Debug)]
+struct ParseError;
+
+impl fmt::Display for ParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("parsing failed")
+    }
+}
+
+impl Error for ParseError {}
+
+#[derive(Debug)]
+struct CallbackFailed;
+
+impl fmt::Display for CallbackFailed {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("callback failed")
+    }
+}
+
+impl Error for CallbackFailed {}
+
+#[derive(Debug)]
+struct MultipleCallbacksFailed;
+
+impl fmt::Display for MultipleCallbacksFailed {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("multiple callbacks failed")
+    }
+}
+
+impl Error for MultipleCallbacksFailed {}
+
+fn read_storage() -> exn::Result<(), StorageError> {
+    Err(StorageError.raise())
+}
+
+fn parse_input() -> exn::Result<(), ParseError> {
+    Err(ParseError.raise())
+}
+
+fn storage_callback() -> Result<(), CallbackExn> {
+    read_storage().map_err(Exn::erase)?;
+    Ok(())
+}
+
+fn parse_callback() -> Result<(), CallbackExn> {
+    parse_input().map_err(Exn::erase)?;
+    Ok(())
+}
+
+fn run_callback(
+    callback: impl FnOnce() -> Result<(), CallbackExn>,
+) -> exn::Result<(), CallbackFailed> {
+    callback().or_raise(|| CallbackFailed)
+}
+
+#[test]
+fn erasure_preserves_the_frame_and_runtime_root_type() {
+    let typed = StorageError.raise();
+    let frame = typed.frame() as *const _;
+    let erased = typed.erase();
+
+    assert_eq!(erased.frame() as *const _, frame);
+    assert!(erased.downcast_ref::<StorageError>().is_some());
+}
+
+#[test]
+fn callback_errors_are_erased_at_the_boundary_and_typed_above_it() {
+    let error = run_callback(storage_callback).unwrap_err();
+
+    assert_eq!(error.to_string(), "callback failed");
+    assert!(
+        error.frame().children()[0]
+            .error()
+            .downcast_ref::<StorageError>()
+            .is_some()
+    );
+}
+
+#[test]
+fn heterogeneous_callback_errors_can_share_one_collection() {
+    let errors = [
+        storage_callback().unwrap_err(),
+        parse_callback().unwrap_err(),
+    ];
+    let error = errors.into_iter().raise(MultipleCallbacksFailed);
+
+    assert!(
+        error.frame().children()[0]
+            .error()
+            .downcast_ref::<StorageError>()
+            .is_some()
+    );
+    assert!(
+        error.frame().children()[1]
+            .error()
+            .downcast_ref::<ParseError>()
+            .is_some()
+    );
+}


### PR DESCRIPTION
## Depends on

- #60, which allows `Exn<E>` and its marker-only adapters to accept an unsized root marker

## Complete workflow

This PR makes type erasure useful specifically at boundaries that require one concrete callback error type while callback implementations retain their own typed errors:

```rust
use exn::ErasedExn;
use exn::Exn;
use exn::ResultExt;

fn storage_callback() -> Result<(), ErasedExn> {
    read_storage()             // exn::Result<_, StorageError>
        .map_err(Exn::erase)?; // erase only at the callback boundary
    Ok(())
}

fn run_callback(
    callback: impl FnOnce() -> Result<(), ErasedExn>,
) -> exn::Result<(), CallbackFailed> {
    callback().or_raise(|| CallbackFailed) // typed again above the boundary
}
```

The intended flow is therefore:

1. keep concrete `Exn<E>` errors inside each module
2. explicitly erase the root marker where a callback or delegate signature must unify unrelated error types
3. immediately add a typed parent when the host incorporates that callback failure into its own API

The same boundary type also allows heterogeneous callback failures to share a collection and be aggregated with `IteratorExt::raise` under one typed parent.

## API

- add the public alias `ErasedExn = Exn<dyn Error + Send + Sync + 'static>`
- add `Exn::erase(self) -> ErasedExn`
- add `Deref<Target = dyn Error + Send + Sync>` for `ErasedExn`

`ErasedExn` gives this common boundary type a standard name without introducing a wrapper or changing its representation. Callers can still define domain-specific aliases such as `CallbackExn` when that improves their API vocabulary.

`erase` only changes the compile-time marker. It moves the existing `Box<Frame>` without allocating, preserves the entire tree, and keeps concrete frame errors available through runtime downcasting.

## Deliberate omissions

- no default type parameter for `Exn`; typed errors remain the default design
- no `From<Exn<E>> for ErasedExn` because it makes `IteratorExt::raise` inference ambiguous between identity conversion and erasure
- no `std::error::Error` wrapper or tree-to-`source()` policy; interoperability is independent from marker erasure

## Open question

- Is `erase` the right consuming-method name, or should it be `into_erased` / `erased`?

## Validation

- `cargo x lint`
- `cargo x test --no-capture`
- doctest covers the typed → erased callback → typed parent workflow
- integration tests verify allocation reuse, runtime downcasting, callback retyping, and heterogeneous iterator aggregation
