### PR TITLE
refactor: make bare Exn the erased type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ All significant changes to this project will be documented in this file.
 
 ### New Features
 
-* Add `ErasedExn` and the allocation-free `Exn::erase` conversion for callback boundaries that cannot name one concrete root error type.
+* Let a bare `Exn` serve as the type-erased boundary type and accept conversions from errors and typed exceptions.
 
 ## v0.3.1 (2026-05-06)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ All significant changes to this project will be documented in this file.
 
 ### New Features
 
-* Let a bare `Exn` serve as the type-erased boundary type, accept conversions from errors and typed exceptions, and provide allocation-free explicit erasure for generic unsized root markers.
+* Let a bare `Exn` serve as the type-erased boundary type and accept conversions from errors and typed exceptions.
 
 ## v0.3.1 (2026-05-06)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ All significant changes to this project will be documented in this file.
 
 ### New Features
 
-* Let a bare `Exn` serve as the type-erased boundary type and accept conversions from errors and typed exceptions.
+* Let a bare `Exn` serve as the type-erased boundary type, accept conversions from errors and typed exceptions, and provide allocation-free explicit erasure for generic unsized root markers.
 
 ## v0.3.1 (2026-05-06)
 

--- a/exn/src/impls.rs
+++ b/exn/src/impls.rs
@@ -33,10 +33,9 @@ use crate::iterator::IteratorExt;
 ///
 /// Without an explicit `E`, `Exn` erases the compile-time root error type. This is useful at
 /// boundaries such as callbacks that need one error type for implementations with different
-/// concrete root errors. Concrete errors and typed exceptions with sized root markers convert into
-/// a bare `Exn`, allowing `?` to perform the erasure. Use [`Exn::erase`] when the root marker may
-/// be unsized. Erasing a typed exception preserves its tree and the runtime types stored in its
-/// frames.
+/// concrete root errors. Both errors and typed exceptions convert into a bare `Exn`, allowing `?`
+/// to perform the erasure. Converting a typed exception preserves its tree and the runtime types
+/// stored in its frames.
 ///
 /// ```
 /// use core::fmt;
@@ -80,14 +79,21 @@ impl<E: Error + Send + Sync + 'static> From<E> for Exn<E> {
 impl<E: Error + Send + Sync + 'static> From<E> for Exn {
     #[track_caller]
     fn from(error: E) -> Self {
-        Exn::new(error).erase()
+        let exn = Exn::new(error);
+        Exn {
+            frame: exn.frame,
+            phantom: PhantomData,
+        }
     }
 }
 
 // Keep `E` sized so this stays disjoint from the standard identity conversion for a bare `Exn`.
 impl<E: Error + Send + Sync + 'static> From<Exn<E>> for Exn {
     fn from(exn: Exn<E>) -> Self {
-        exn.erase()
+        Exn {
+            frame: exn.frame,
+            phantom: PhantomData,
+        }
     }
 }
 
@@ -151,33 +157,6 @@ impl<E: Error + Send + Sync + 'static> Exn<E> {
 }
 
 impl<E: Error + Send + Sync + 'static + ?Sized> Exn<E> {
-    /// Erase the compile-time root error type of this exception.
-    ///
-    /// This conversion does not allocate or change the exception tree. The concrete root error
-    /// remains available at runtime through `downcast_ref` on the erased `Exn`.
-    ///
-    /// Concrete root markers also support conversion into a bare `Exn` through [`Into`]. This
-    /// method additionally works in generic code where the root marker may be unsized.
-    ///
-    /// ```
-    /// use core::error::Error;
-    ///
-    /// use exn::Exn;
-    ///
-    /// fn erase<E>(exn: Exn<E>) -> Exn
-    /// where
-    ///     E: Error + Send + Sync + 'static + ?Sized,
-    /// {
-    ///     exn.erase()
-    /// }
-    /// ```
-    pub fn erase(self) -> Exn {
-        Exn {
-            frame: self.frame,
-            phantom: PhantomData,
-        }
-    }
-
     /// Raise a new exception; this will make the current exception a child of the new one.
     #[track_caller]
     pub fn raise<T: Error + Send + Sync + 'static>(self, err: T) -> Exn<T> {

--- a/exn/src/impls.rs
+++ b/exn/src/impls.rs
@@ -33,9 +33,10 @@ use crate::iterator::IteratorExt;
 ///
 /// Without an explicit `E`, `Exn` erases the compile-time root error type. This is useful at
 /// boundaries such as callbacks that need one error type for implementations with different
-/// concrete root errors. Both errors and typed exceptions convert into a bare `Exn`, allowing `?`
-/// to perform the erasure. Converting a typed exception preserves its tree and the runtime types
-/// stored in its frames.
+/// concrete root errors. Concrete errors and typed exceptions with sized root markers convert into
+/// a bare `Exn`, allowing `?` to perform the erasure. Use [`Exn::erase`] when the root marker may
+/// be unsized. Erasing a typed exception preserves its tree and the runtime types stored in its
+/// frames.
 ///
 /// ```
 /// use core::fmt;
@@ -79,21 +80,14 @@ impl<E: Error + Send + Sync + 'static> From<E> for Exn<E> {
 impl<E: Error + Send + Sync + 'static> From<E> for Exn {
     #[track_caller]
     fn from(error: E) -> Self {
-        let exn = Exn::new(error);
-        Exn {
-            frame: exn.frame,
-            phantom: PhantomData,
-        }
+        Exn::new(error).erase()
     }
 }
 
 // Keep `E` sized so this stays disjoint from the standard identity conversion for a bare `Exn`.
 impl<E: Error + Send + Sync + 'static> From<Exn<E>> for Exn {
     fn from(exn: Exn<E>) -> Self {
-        Exn {
-            frame: exn.frame,
-            phantom: PhantomData,
-        }
+        exn.erase()
     }
 }
 
@@ -157,6 +151,33 @@ impl<E: Error + Send + Sync + 'static> Exn<E> {
 }
 
 impl<E: Error + Send + Sync + 'static + ?Sized> Exn<E> {
+    /// Erase the compile-time root error type of this exception.
+    ///
+    /// This conversion does not allocate or change the exception tree. The concrete root error
+    /// remains available at runtime through `downcast_ref` on the erased `Exn`.
+    ///
+    /// Concrete root markers also support conversion into a bare `Exn` through [`Into`]. This
+    /// method additionally works in generic code where the root marker may be unsized.
+    ///
+    /// ```
+    /// use core::error::Error;
+    ///
+    /// use exn::Exn;
+    ///
+    /// fn erase<E>(exn: Exn<E>) -> Exn
+    /// where
+    ///     E: Error + Send + Sync + 'static + ?Sized,
+    /// {
+    ///     exn.erase()
+    /// }
+    /// ```
+    pub fn erase(self) -> Exn {
+        Exn {
+            frame: self.frame,
+            phantom: PhantomData,
+        }
+    }
+
     /// Raise a new exception; this will make the current exception a child of the new one.
     #[track_caller]
     pub fn raise<T: Error + Send + Sync + 'static>(self, err: T) -> Exn<T> {

--- a/exn/src/impls.rs
+++ b/exn/src/impls.rs
@@ -25,19 +25,45 @@ use core::panic::Location;
 
 use crate::iterator::IteratorExt;
 
-/// An [`Exn`] whose compile-time root error type has been erased.
-///
-/// Use this at boundaries such as callbacks that need one error type for implementations with
-/// different concrete root errors. Prefer a typed [`Exn<E>`](Exn) away from those boundaries.
-/// Create an `ErasedExn` with [`Exn::erase`].
-pub type ErasedExn = Exn<dyn Error + Send + Sync + 'static>;
-
 /// An exception type that can hold an error tree and additional context.
 ///
 /// `E` identifies the root error type but is not stored inline, so it may be unsized. Operations
 /// that construct a new root error, such as [`Exn::new`] and [`Exn::raise`], still accept their new
 /// error by value and therefore require that type to be sized.
-pub struct Exn<E: Error + Send + Sync + 'static + ?Sized> {
+///
+/// Without an explicit `E`, `Exn` erases the compile-time root error type. This is useful at
+/// boundaries such as callbacks that need one error type for implementations with different
+/// concrete root errors. Both errors and typed exceptions convert into a bare `Exn`, allowing `?`
+/// to perform the erasure. Converting a typed exception preserves its tree and the runtime types
+/// stored in its frames.
+///
+/// ```
+/// use core::fmt;
+///
+/// use exn::ErrorExt;
+/// use exn::Exn;
+/// use exn::ResultExt;
+///
+/// fn callback() -> Result<(), Exn> {
+///     let result: exn::Result<(), std::io::Error> =
+///         Err(std::io::Error::other("callback failed").raise());
+///     result?;
+///     Ok(())
+/// }
+///
+/// fn run(callback: impl FnOnce() -> Result<(), Exn>) -> exn::Result<(), fmt::Error> {
+///     callback().or_raise(|| fmt::Error)
+/// }
+///
+/// let error = run(callback).unwrap_err();
+/// assert!(
+///     error.frame().children()[0]
+///         .error()
+///         .downcast_ref::<std::io::Error>()
+///         .is_some()
+/// );
+/// ```
+pub struct Exn<E: Error + Send + Sync + 'static + ?Sized = dyn Error + Send + Sync + 'static> {
     // trade one more indirection for less stack size
     frame: Box<Frame>,
     phantom: PhantomData<E>,
@@ -47,6 +73,27 @@ impl<E: Error + Send + Sync + 'static> From<E> for Exn<E> {
     #[track_caller]
     fn from(error: E) -> Self {
         Exn::new(error)
+    }
+}
+
+impl<E: Error + Send + Sync + 'static> From<E> for Exn {
+    #[track_caller]
+    fn from(error: E) -> Self {
+        let exn = Exn::new(error);
+        Exn {
+            frame: exn.frame,
+            phantom: PhantomData,
+        }
+    }
+}
+
+// Keep `E` sized so this stays disjoint from the standard identity conversion for a bare `Exn`.
+impl<E: Error + Send + Sync + 'static> From<Exn<E>> for Exn {
+    fn from(exn: Exn<E>) -> Self {
+        Exn {
+            frame: exn.frame,
+            phantom: PhantomData,
+        }
     }
 }
 
@@ -110,47 +157,6 @@ impl<E: Error + Send + Sync + 'static> Exn<E> {
 }
 
 impl<E: Error + Send + Sync + 'static + ?Sized> Exn<E> {
-    /// Erase the compile-time root error type of this exception.
-    ///
-    /// This conversion does not allocate or change the exception tree. The concrete root error
-    /// remains available at runtime through `Error::downcast_ref`.
-    ///
-    /// Type erasure is useful at callback boundaries that need one return type for callbacks with
-    /// different concrete error types. Prefer a typed [`Exn<E>`](Exn) away from such boundaries.
-    ///
-    /// ```
-    /// use core::fmt;
-    ///
-    /// use exn::ErasedExn;
-    /// use exn::ErrorExt;
-    /// use exn::Exn;
-    /// use exn::ResultExt;
-    ///
-    /// fn callback() -> Result<(), ErasedExn> {
-    ///     let result: exn::Result<(), std::io::Error> =
-    ///         Err(std::io::Error::other("callback failed").raise());
-    ///     result.map_err(Exn::erase)
-    /// }
-    ///
-    /// fn run(callback: impl FnOnce() -> Result<(), ErasedExn>) -> exn::Result<(), fmt::Error> {
-    ///     callback().or_raise(|| fmt::Error)
-    /// }
-    ///
-    /// let error = run(callback).unwrap_err();
-    /// assert!(
-    ///     error.frame().children()[0]
-    ///         .error()
-    ///         .downcast_ref::<std::io::Error>()
-    ///         .is_some()
-    /// );
-    /// ```
-    pub fn erase(self) -> ErasedExn {
-        Exn {
-            frame: self.frame,
-            phantom: PhantomData,
-        }
-    }
-
     /// Raise a new exception; this will make the current exception a child of the new one.
     #[track_caller]
     pub fn raise<T: Error + Send + Sync + 'static>(self, err: T) -> Exn<T> {
@@ -167,16 +173,15 @@ impl<E: Error + Send + Sync + 'static + ?Sized> Exn<E> {
 
 impl<I: Iterator> IteratorExt for I {
     #[track_caller]
-    fn raise<P, C>(self, parent: P) -> Exn<P>
+    fn raise<P>(self, parent: P) -> Exn<P>
     where
         P: Error + Send + Sync + 'static,
-        C: Error + Send + Sync + 'static + ?Sized,
-        I::Item: Into<Exn<C>>,
+        I::Item: Into<Exn>,
     {
         let mut new_exn = Exn::new(parent);
-        for exn in self {
-            let exn = exn.into();
-            new_exn.frame.children.push(*exn.frame);
+        for item in self {
+            let child: Exn = item.into();
+            new_exn.frame.children.push(*child.frame);
         }
         new_exn
     }
@@ -196,7 +201,7 @@ where
     }
 }
 
-impl Deref for ErasedExn {
+impl Deref for Exn {
     type Target = dyn Error + Send + Sync + 'static;
 
     fn deref(&self) -> &Self::Target {

--- a/exn/src/iterator.rs
+++ b/exn/src/iterator.rs
@@ -24,9 +24,6 @@ pub trait IteratorExt: Iterator {
     /// and becomes a direct child of the new exception in iteration order. An empty iterator
     /// creates an exception with no children.
     ///
-    /// An [`Exn`] with a sized root marker converts implicitly. In generic code where the marker
-    /// may be unsized, erase each item explicitly with [`Exn::erase`] before calling this method.
-    ///
     /// # Examples
     ///
     /// ```

--- a/exn/src/iterator.rs
+++ b/exn/src/iterator.rs
@@ -24,6 +24,9 @@ pub trait IteratorExt: Iterator {
     /// and becomes a direct child of the new exception in iteration order. An empty iterator
     /// creates an exception with no children.
     ///
+    /// An [`Exn`] with a sized root marker converts implicitly. In generic code where the marker
+    /// may be unsized, erase each item explicitly with [`Exn::erase`] before calling this method.
+    ///
     /// # Examples
     ///
     /// ```

--- a/exn/src/iterator.rs
+++ b/exn/src/iterator.rs
@@ -20,9 +20,9 @@ use crate::Exn;
 pub trait IteratorExt: Iterator {
     /// Raise a new parent exception over every exception in this iterator.
     ///
-    /// Each item, whether an error or an existing [`Exn`], becomes a direct child of the new
-    /// exception in iteration order. All items must have the same root error type. An empty
-    /// iterator creates an exception with no children.
+    /// Each item, whether an error or an existing [`Exn`], is converted into a type-erased `Exn`
+    /// and becomes a direct child of the new exception in iteration order. An empty iterator
+    /// creates an exception with no children.
     ///
     /// # Examples
     ///
@@ -59,10 +59,9 @@ pub trait IteratorExt: Iterator {
     /// assert_eq!(error.frame().children().len(), 2);
     /// ```
     #[track_caller]
-    fn raise<P, C>(self, parent: P) -> Exn<P>
+    fn raise<P>(self, parent: P) -> Exn<P>
     where
         Self: Sized,
         P: Error + Send + Sync + 'static,
-        C: Error + Send + Sync + 'static + ?Sized,
-        Self::Item: Into<Exn<C>>;
+        Self::Item: Into<Exn>;
 }

--- a/exn/src/lib.rs
+++ b/exn/src/lib.rs
@@ -88,7 +88,6 @@ mod result;
 
 pub use self::ext::ErrorExt;
 pub use self::ext::Ok;
-pub use self::impls::ErasedExn;
 pub use self::impls::Exn;
 pub use self::impls::Frame;
 pub use self::iterator::IteratorExt;

--- a/exn/src/macros.rs
+++ b/exn/src/macros.rs
@@ -56,9 +56,7 @@ macro_rules! bail {
 /// ```
 /// # fn has_permission(_: &u32, _: &u32) -> bool { true }
 /// # type User = u32;
-/// # let user = 0;
 /// # type Resource = u32;
-/// # let resource = 0;
 /// use core::error::Error;
 /// use core::fmt;
 ///
@@ -75,11 +73,12 @@ macro_rules! bail {
 ///
 /// impl Error for PermissionDenied {}
 ///
+/// # fn wrapper(user: User, resource: Resource) -> exn::Result<(), PermissionDenied> {
 /// ensure!(
 ///     has_permission(&user, &resource),
 ///     PermissionDenied(user, resource),
 /// );
-/// # Ok(())
+/// # Ok(()) }
 /// ```
 #[macro_export]
 macro_rules! ensure {

--- a/exn/tests/erasure.rs
+++ b/exn/tests/erasure.rs
@@ -15,7 +15,6 @@
 use core::error::Error;
 use core::fmt;
 
-use exn::ErasedExn;
 use exn::ErrorExt;
 use exn::Exn;
 use exn::IteratorExt;
@@ -73,19 +72,22 @@ fn parse_input() -> exn::Result<(), ParseError> {
     Err(ParseError.raise())
 }
 
-fn storage_callback() -> Result<(), ErasedExn> {
-    read_storage().map_err(Exn::erase)?;
+fn storage_callback() -> Result<(), Exn> {
+    read_storage()?;
     Ok(())
 }
 
-fn parse_callback() -> Result<(), ErasedExn> {
-    parse_input().map_err(Exn::erase)?;
+fn parse_callback() -> Result<(), Exn> {
+    parse_input()?;
     Ok(())
 }
 
-fn run_callback(
-    callback: impl FnOnce() -> Result<(), ErasedExn>,
-) -> exn::Result<(), CallbackFailed> {
+fn plain_error_callback() -> Result<(), Exn> {
+    Err(StorageError)?;
+    Ok(())
+}
+
+fn run_callback(callback: impl FnOnce() -> Result<(), Exn>) -> exn::Result<(), CallbackFailed> {
     callback().or_raise(|| CallbackFailed)
 }
 
@@ -93,7 +95,7 @@ fn run_callback(
 fn erasure_preserves_the_frame_and_runtime_root_type() {
     let typed = StorageError.raise();
     let frame = typed.frame() as *const _;
-    let erased = typed.erase();
+    let erased: Exn = typed.into();
 
     assert_eq!(erased.frame() as *const _, frame);
     assert!(erased.downcast_ref::<StorageError>().is_some());
@@ -110,6 +112,13 @@ fn callback_errors_are_erased_at_the_boundary_and_typed_above_it() {
             .downcast_ref::<StorageError>()
             .is_some()
     );
+}
+
+#[test]
+fn plain_errors_convert_into_a_bare_exn() {
+    let error = plain_error_callback().unwrap_err();
+
+    assert!(error.downcast_ref::<StorageError>().is_some());
 }
 
 #[test]

--- a/exn/tests/erasure.rs
+++ b/exn/tests/erasure.rs
@@ -91,6 +91,15 @@ fn run_callback(callback: impl FnOnce() -> Result<(), Exn>) -> exn::Result<(), C
     callback().or_raise(|| CallbackFailed)
 }
 
+fn raise_with_potentially_unsized_marker<E>(
+    errors: impl Iterator<Item = Exn<E>>,
+) -> Exn<MultipleCallbacksFailed>
+where
+    E: Error + Send + Sync + 'static + ?Sized,
+{
+    errors.map(Exn::erase).raise(MultipleCallbacksFailed)
+}
+
 #[test]
 fn erasure_preserves_the_frame_and_runtime_root_type() {
     let typed = StorageError.raise();
@@ -139,6 +148,20 @@ fn heterogeneous_callback_errors_can_share_one_collection() {
         error.frame().children()[1]
             .error()
             .downcast_ref::<ParseError>()
+            .is_some()
+    );
+}
+
+#[test]
+fn generic_potentially_unsized_markers_can_be_erased_before_iterator_raise() {
+    let errors = [StorageError.raise(), StorageError.raise()];
+    let error = raise_with_potentially_unsized_marker(errors.into_iter());
+
+    assert_eq!(error.frame().children().len(), 2);
+    assert!(
+        error.frame().children()[0]
+            .error()
+            .downcast_ref::<StorageError>()
             .is_some()
     );
 }

--- a/exn/tests/erasure.rs
+++ b/exn/tests/erasure.rs
@@ -91,15 +91,6 @@ fn run_callback(callback: impl FnOnce() -> Result<(), Exn>) -> exn::Result<(), C
     callback().or_raise(|| CallbackFailed)
 }
 
-fn raise_with_potentially_unsized_marker<E>(
-    errors: impl Iterator<Item = Exn<E>>,
-) -> Exn<MultipleCallbacksFailed>
-where
-    E: Error + Send + Sync + 'static + ?Sized,
-{
-    errors.map(Exn::erase).raise(MultipleCallbacksFailed)
-}
-
 #[test]
 fn erasure_preserves_the_frame_and_runtime_root_type() {
     let typed = StorageError.raise();
@@ -148,20 +139,6 @@ fn heterogeneous_callback_errors_can_share_one_collection() {
         error.frame().children()[1]
             .error()
             .downcast_ref::<ParseError>()
-            .is_some()
-    );
-}
-
-#[test]
-fn generic_potentially_unsized_markers_can_be_erased_before_iterator_raise() {
-    let errors = [StorageError.raise(), StorageError.raise()];
-    let error = raise_with_potentially_unsized_marker(errors.into_iter());
-
-    assert_eq!(error.frame().children().len(), 2);
-    assert!(
-        error.frame().children()[0]
-            .error()
-            .downcast_ref::<StorageError>()
             .is_some()
     );
 }


### PR DESCRIPTION
Stacked on #61.

## Summary

- make bare `Exn` default to `dyn Error + Send + Sync`
- convert plain errors and typed `Exn<E>` into bare `Exn`, allowing `?` at erased boundaries
- simplify `IteratorExt::raise` to erase child markers through `Into<Exn>`
- remove the separate `ErasedExn` alias and `Exn::erase`

## Design Notes

In a type position, the default parameter makes `Into<Exn>` equivalent to `Into<Exn<dyn Error + Send + Sync + 'static>>`.

Concrete errors and `Exn<E>` values with sized root markers convert into bare `Exn`, so they work directly with `IteratorExt::raise`. Bare `Exn` values use the standard identity conversion. Together these cover the supported typed and erased states.

The `?Sized` marker bounds allow the standard erased `dyn Error + Send + Sync` default without reallocating or changing the exception tree. This PR does not provide conversion to arbitrary custom trait-object markers such as `Exn<dyn CustomError>`.

## Validation

- `cargo x lint`
- `cargo x test --no-capture`
- integration coverage for automatic callback erasure, typed and erased iterator items, allocation reuse, and runtime downcasting
