### PR TITLE
chore: prepare exn v0.4.0-rc.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,14 +4,22 @@ All significant changes to this project will be documented in this file.
 
 ## Unreleased
 
+## v0.4.0-rc.1 (2026-08-24)
+
 ### Breaking Changes
 
-* Replace `Exn::raise_all(parent, children)` with `children.into_iter().raise(parent)` from the new `IteratorExt` trait.
-* Remove the unused `ResultExt::Error` associated type.
+* Remove `Exn::raise_all(parent, children)`. Import `IteratorExt` and use `children.into_iter().raise(parent)` instead.
+* Remove the unused `ResultExt::Error` associated type. Generic code that named it must carry the error type separately.
 
 ### New Features
 
-* Let a bare `Exn` serve as the type-erased boundary type and accept conversions from errors and typed exceptions.
+* Let a bare `Exn` serve as the standard type-erased boundary. Concrete errors and typed `Exn<E>` values convert into it through `From` and `?`; converting a typed exception preserves its complete frame tree and runtime error types without another allocation.
+* Add `IteratorExt::raise` to aggregate an iterator of errors or typed or type-erased exceptions beneath one typed parent.
+* Allow `Exn<E>` and marker-only adapters to use unsized root markers. Construction still requires a sized error passed by value, and conversion into arbitrary custom trait-object markers is not provided.
+
+### Packaging
+
+* Include the Apache-2.0 license in the published `exn` package.
 
 ## v0.3.1 (2026-05-06)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -165,7 +165,7 @@ dependencies = [
 
 [[package]]
 name = "exn"
-version = "0.3.1"
+version = "0.4.0-rc.1"
 dependencies = [
  "insta",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ rust-version = "1.85.0"
 
 [workspace.dependencies]
 # Workspace dependencies
-exn = { version = "0.3.1", path = "exn" }
+exn = { version = "0.4.0-rc.1", path = "exn" }
 exn-anyhow = { version = "0.1.0", path = "exn-anyhow" }
 
 # Crates.io dependencies

--- a/README.md
+++ b/README.md
@@ -22,41 +22,9 @@
 
 It organizes errors as a tree, preserving typed context at module boundaries while still supporting type erasure where one concrete error type cannot be named.
 
-## Typed and erased boundaries
-
-Prefer `exn::Result<T, E>` with a concrete `E` inside modules and in domain APIs. This keeps the current root error visible in the type system.
-
-Use a bare `Exn` at boundaries that genuinely need one concrete error type for unrelated implementations, such as callbacks, delegates, or heterogeneous collections. Typed exceptions convert into a bare `Exn` through `?` without reallocating their frame tree, and their concrete frame errors remain available for runtime downcasting. Add a typed parent again when the surrounding component incorporates the failure into its own API.
-
-```rust
-use core::fmt;
-use std::io;
-
-use exn::ErrorExt;
-use exn::Exn;
-use exn::ResultExt;
-
-fn read_config() -> exn::Result<(), io::Error> {
-    Err(io::Error::other("cannot read config").raise())
-}
-
-fn callback() -> Result<(), Exn> {
-    read_config()?;
-    Ok(())
-}
-
-fn run_callback(callback: impl FnOnce() -> Result<(), Exn>) -> exn::Result<(), fmt::Error> {
-    callback().or_raise(|| fmt::Error)
-}
-```
-
-## Migrating from 0.3
-
-Import `exn::IteratorExt` and replace `Exn::raise_all(parent, children)` with `children.into_iter().raise(parent)`. Remove references to the unused `ResultExt::Error` associated type; there is no replacement associated type. See the [changelog](https://github.com/fast/exn/blob/main/CHANGELOG.md) for the complete 0.4 release notes.
-
 ## Documentation
 
-Read the online documents at https://docs.rs/exn.
+Read the [API documentation](https://docs.rs/exn) for examples and guidance on choosing typed and erased boundaries. See the [changelog](https://github.com/fast/exn/blob/main/CHANGELOG.md) for version-specific migration notes.
 
 ## `no_std` crates
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ It organizes errors as a tree, preserving typed context at module boundaries whi
 
 ## Documentation
 
-Read the [API documentation](https://docs.rs/exn) for examples and guidance on choosing typed and erased boundaries. See the [changelog](https://github.com/fast/exn/blob/main/CHANGELOG.md) for version-specific migration notes.
+Read the [API documentation](https://docs.rs/exn) for examples and guidance on choosing typed and erased boundaries. See the [CHANGELOG](CHANGELOG.md) for version-specific migration notes.
 
 ## `no_std` crates
 

--- a/README.md
+++ b/README.md
@@ -14,13 +14,45 @@
 [license-badge]: https://img.shields.io/crates/l/exn
 [license-url]: LICENSE
 [actions-badge]: https://github.com/fast/exn/workflows/CI/badge.svg
-[actions-url]:https://github.com/fast/exn/actions?query=workflow%3ACI
+[actions-url]: https://github.com/fast/exn/actions?query=workflow%3ACI
 
 ## Overview
 
 `exn` provides the missing context APIs for `core::error::Error`.
 
-It organizes errors as a tree structure, allowing you to easily access the root cause and all related errors with their context.
+It organizes errors as a tree, preserving typed context at module boundaries while still supporting type erasure where one concrete error type cannot be named.
+
+## Typed and erased boundaries
+
+Prefer `exn::Result<T, E>` with a concrete `E` inside modules and in domain APIs. This keeps the current root error visible in the type system.
+
+Use a bare `Exn` at boundaries that genuinely need one concrete error type for unrelated implementations, such as callbacks, delegates, or heterogeneous collections. Typed exceptions convert into a bare `Exn` through `?` without reallocating their frame tree, and their concrete frame errors remain available for runtime downcasting. Add a typed parent again when the surrounding component incorporates the failure into its own API.
+
+```rust
+use core::fmt;
+use std::io;
+
+use exn::ErrorExt;
+use exn::Exn;
+use exn::ResultExt;
+
+fn read_config() -> exn::Result<(), io::Error> {
+    Err(io::Error::other("cannot read config").raise())
+}
+
+fn callback() -> Result<(), Exn> {
+    read_config()?;
+    Ok(())
+}
+
+fn run_callback(callback: impl FnOnce() -> Result<(), Exn>) -> exn::Result<(), fmt::Error> {
+    callback().or_raise(|| fmt::Error)
+}
+```
+
+## Migrating from 0.3
+
+Import `exn::IteratorExt` and replace `Exn::raise_all(parent, children)` with `children.into_iter().raise(parent)`. Remove references to the unused `ResultExt::Error` associated type; there is no replacement associated type. See the [changelog](https://github.com/fast/exn/blob/main/CHANGELOG.md) for the complete 0.4 release notes.
 
 ## Documentation
 

--- a/exn/Cargo.toml
+++ b/exn/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "exn"
-version = "0.3.1"
+version = "0.4.0-rc.1"
 
 description = "A context-aware concrete Error type built on `core::error::Error`."
 

--- a/exn/src/impls.rs
+++ b/exn/src/impls.rs
@@ -36,33 +36,6 @@ use crate::iterator::IteratorExt;
 /// concrete root errors. Both errors and typed exceptions convert into a bare `Exn`, allowing `?`
 /// to perform the erasure. Converting a typed exception preserves its tree and the runtime types
 /// stored in its frames.
-///
-/// ```
-/// use core::fmt;
-///
-/// use exn::ErrorExt;
-/// use exn::Exn;
-/// use exn::ResultExt;
-///
-/// fn callback() -> Result<(), Exn> {
-///     let result: exn::Result<(), std::io::Error> =
-///         Err(std::io::Error::other("callback failed").raise());
-///     result?;
-///     Ok(())
-/// }
-///
-/// fn run(callback: impl FnOnce() -> Result<(), Exn>) -> exn::Result<(), fmt::Error> {
-///     callback().or_raise(|| fmt::Error)
-/// }
-///
-/// let error = run(callback).unwrap_err();
-/// assert!(
-///     error.frame().children()[0]
-///         .error()
-///         .downcast_ref::<std::io::Error>()
-///         .is_some()
-/// );
-/// ```
 pub struct Exn<E: Error + Send + Sync + 'static + ?Sized = dyn Error + Send + Sync + 'static> {
     // trade one more indirection for less stack size
     frame: Box<Frame>,

--- a/exn/src/lib.rs
+++ b/exn/src/lib.rs
@@ -80,7 +80,38 @@
 //! allocation. Add a typed parent with [`ResultExt::or_raise`] when the surrounding component
 //! incorporates the failure into its own API.
 //!
-//! The [`Exn`] documentation shows the complete typed-to-erased-to-typed callback workflow.
+//! ```
+//! use core::fmt;
+//! use std::io;
+//!
+//! use exn::ErrorExt;
+//! use exn::Exn;
+//! use exn::ResultExt;
+//!
+//! fn read_config() -> exn::Result<(), io::Error> {
+//!     Err(io::Error::other("cannot read config").raise())
+//! }
+//!
+//! fn callback() -> Result<(), Exn> {
+//!     read_config()?;
+//!     Ok(())
+//! }
+//!
+//! fn run_callback(callback: impl FnOnce() -> Result<(), Exn>) -> exn::Result<(), fmt::Error> {
+//!     callback().or_raise(|| fmt::Error)
+//! }
+//!
+//! let error = run_callback(callback).unwrap_err();
+//! assert!(
+//!     error.frame().children()[0]
+//!         .error()
+//!         .downcast_ref::<io::Error>()
+//!         .is_some()
+//! );
+//! ```
+//!
+//! A bare `Exn` also lets failures with different concrete root types share a collection.
+//! [`IteratorExt::raise`] can then aggregate them beneath one typed parent.
 
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![deny(missing_docs)]

--- a/exn/src/lib.rs
+++ b/exn/src/lib.rs
@@ -70,6 +70,17 @@
 //! fatal error: math no longer works, at exn/src/lib.rs:44:16
 //! `-- logic error: 0 == 1, at exn/src/lib.rs:40:5
 //! ```
+//!
+//! # Typed and erased boundaries
+//!
+//! Prefer [`Result`] with a concrete root error type inside modules and in domain APIs. Use a bare
+//! [`Exn`] when a boundary, such as a callback or delegate, cannot name one concrete root error
+//! type. Concrete errors and typed exceptions convert into a bare `Exn` through `From` and `?`.
+//! Converting a typed exception preserves its frame tree and runtime error types without another
+//! allocation. Add a typed parent with [`ResultExt::or_raise`] when the surrounding component
+//! incorporates the failure into its own API.
+//!
+//! The [`Exn`] documentation shows the complete typed-to-erased-to-typed callback workflow.
 
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![deny(missing_docs)]


### PR DESCRIPTION
## Summary

- bump only `exn` to `0.4.0-rc.1`; keep `exn-anyhow` at its independently released `0.1.0`
- turn the unreleased notes into complete RC release notes, including both expected breaking changes and the exact `?Sized` scope
- document the recommended typed module API → erased callback boundary → typed parent workflow
- add concise migration guidance for `IteratorExt::raise` and the removed `ResultExt::Error`

## Release plan

This PR prepares the release but does not publish or tag it.

After merge:

1. Run `cargo release --package exn --prev-tag-name v0.3.1 --execute` to publish only `exn` and create the signed `v0.4.0-rc.1` tag. A GitHub Release is not required.
2. Replace the vendored/forked error implementation in gitoxide with the RC and validate the real callback/delegate workflow.
3. Address any integration findings, then prepare `exn v0.4.0`. `exn-anyhow` remains on its own release cadence.

The cargo-release dry run explicitly skips `exn-anyhow`.

## API audit

`cargo-semver-checks` against 0.3.1 reports exactly the two intentional breaking changes documented here:

- removal of `Exn::raise_all`
- removal of `ResultExt::Error`

There are currently no open issues. #35 is covered by #60, #61, and #62.

## Validation

- `cargo x lint`
- `cargo x test --no-capture`
- `cargo package --package exn --allow-dirty`
- `cargo release --package exn --prev-tag-name v0.3.1 --verbose` (dry run)
